### PR TITLE
chore: ignore irrelevant directories

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,1 +1,3 @@
 /node_modules
+/.circleci
+/e2e


### PR DESCRIPTION
these directories are not in anyway needed for the static build process over at now.sh